### PR TITLE
[BLOCKED] Support AMD eGPU hotplug

### DIFF
--- a/nix/nixos/base-configuration.nix
+++ b/nix/nixos/base-configuration.nix
@@ -358,6 +358,16 @@ in
     xserver = {
       enable = true;
       exportConfiguration = true;
+      # attempt this after xorg-server 1.20.15 is released
+      # https://www.phoronix.com/news/X.Org-Server-HotplugDriver
+      extraConfig = ''
+        Section "OutputClass"
+                Identifier "AMDgpu"
+                MatchDriver "amdgpu"
+                Driver "amdgpu"
+                HotplugDriver "amdgpu"
+        EndSection
+      '';
       libinput = {
         enable = true;
         touchpad = {


### PR DESCRIPTION
The [relevant change](https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/879) will likely available in the next release ~[`21.1.7`](https://gitlab.freedesktop.org/xorg/xserver/-/tree/xorg-server-21.1.7)~ (this is only a CVE release), maybe [`21.1.9`](https://gitlab.freedesktop.org/xorg/xserver/-/tree/xorg-server-21.1.9)

NixOS is bumping to `21.1.7` (https://github.com/NixOS/nixpkgs/pull/206805), which doesn't include the patch

[Reference article](https://www.phoronix.com/news/X.Org-Server-HotplugDriver)

Reference error when running on `1.20.14`:
```
[     6.155] 
X.Org X Server 1.20.14
X Protocol Version 11, Revision 0
[     6.155] Build Operating System: Nix 
[     6.155] Current Operating System: Linux xps 6.1.0 #1-NixOS SMP PREEMPT_DYNAMIC Sun Dec 11 22:15:18 UTC 2022 x86_64
[     6.155] Kernel command line: initrd=\efi\nixos\rqvjibygqpd7jghmxzikywpc9b8hkpjc-initrd-linux-6.1-initrd.efi init=/nix/store/1gr5840xyw6zyvr3f99v6r59ydy2h39r-nixos-system-xps-22.11.20221220.cbe419e/init loglevel=4
[     6.155] Build Date: 15 December 2021  07:01:53PM
[     6.155]  
[     6.155] Current version of pixman: 0.42.2
[     6.155] 	Before reporting problems, check http://wiki.x.org
	to make sure that you have the latest version.
[     6.155] Markers: (--) probed, (**) from config file, (==) default setting,
	(++) from command line, (!!) notice, (II) informational,
	(WW) warning, (EE) error, (NI) not implemented, (??) unknown.
[     6.155] (++) Log file: "/var/log/X.0.log", Time: Mon Jan  9 14:18:32 2023
[     6.155] (++) Using config file: "/nix/store/fm3hlpscllbawr7aq8z0i86w0zzrdchn-xserver.conf"
[     6.155] (==) Using config directory: "/etc/X11/xorg.conf.d"
[     6.155] (==) Using system config directory "/nix/store/40im6jrhxphm71k79dm0mf5083kl5jlz-xorg-server-1.20.14/share/X11/xorg.conf.d"
[     6.155] Parse error on line 334 of section OutputClass in file /nix/store/fm3hlpscllbawr7aq8z0i86w0zzrdchn-xserver.conf
	"HotplugDriver" is not a valid keyword in this section.
[     6.155] (EE) Problem parsing the config file
[     6.155] (EE) Error parsing the config file
[     6.155] (EE) 
Fatal server error:
[     6.155] (EE) no screens found(EE) 
[     6.155] (EE) 
Please consult the The X.Org Foundation support 
	 at http://wiki.x.org
 for help. 
[     6.155] (EE) Please also check the log file at "/var/log/X.0.log" for additional information.
[     6.155] (EE) 
[     6.155] (EE) Server terminated with error (1). Closing log file.
```